### PR TITLE
[codex] Productize distribution and demo packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Compile core files
         run: |
-          python -m compileall -q self_improving_loop examples
+          python -m compileall -q self_improving_loop examples demo
 
       - name: Run tests
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 
 on:
+  release:
+    types: [published]
   push:
     tags:
       - "v*"
@@ -35,7 +37,7 @@ jobs:
 
       - name: Compile core files
         run: |
-          python -m compileall -q self_improving_loop examples benchmarks
+          python -m compileall -q self_improving_loop examples benchmarks demo
 
       - name: Build wheel and sdist
         run: |
@@ -55,7 +57,7 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
     environment: pypi
     permissions:
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ Thumbs.db
 *.egg
 pip-wheel-metadata/
 .repro-demo/
+.demo-traces/
 decision_audit.jsonl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include CHANGELOG.md
 recursive-include examples *.py *.md
 recursive-include benchmarks *.py
+recursive-include demo *.py *.md *.txt

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > Preserve event evidence.
 
 [![GitHub Release](https://img.shields.io/github/v/release/yangfei222666-9/self-improving-loop?display_name=tag)](https://github.com/yangfei222666-9/self-improving-loop/releases/tag/v0.1.1)
+[![PyPI](https://img.shields.io/pypi/v/self-improving-loop.svg)](https://pypi.org/project/self-improving-loop/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/self-improving-loop.svg)](https://pypi.org/project/self-improving-loop/)
 [![CI](https://github.com/yangfei222666-9/self-improving-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/yangfei222666-9/self-improving-loop/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
@@ -48,7 +50,13 @@ Demo artifacts: [terminal transcript](assets/demo/self_improving_loop_demo.txt) 
 
 ## Install
 
-Latest verified GitHub release:
+PyPI:
+
+```bash
+pip install self-improving-loop
+```
+
+Latest verified GitHub release artifact:
 
 ```bash
 pip install https://github.com/yangfei222666-9/self-improving-loop/releases/download/v0.1.1/self_improving_loop-0.1.1-py3-none-any.whl
@@ -62,6 +70,22 @@ pip install git+https://github.com/yangfei222666-9/self-improving-loop.git@v0.1.
 
 Zero required dependencies. Everything is Python stdlib, including optional
 SQLite trace storage via `sqlite3`.
+
+---
+
+## Demo
+
+Local Streamlit demo:
+
+```bash
+python3 -m pip install streamlit
+python3 -m streamlit run demo/huggingface_space/app.py
+```
+
+Hugging Face Space source lives in
+[`demo/huggingface_space/`](demo/huggingface_space/). Create a public
+Streamlit Space and upload `app.py` plus `requirements.txt`. Until that Space is
+created, this repository contains demo source, not a public showcase URL.
 
 ---
 
@@ -96,7 +120,7 @@ Experimental:
 
 ---
 
-## 30-second example
+## Quickstart
 
 ```python
 from self_improving_loop import SelfImprovingLoop
@@ -194,6 +218,21 @@ python3 examples/wrap_existing_agent.py
 
 The goal is narrow: traces, thresholds, guarded strategy application, and
 rollback evidence around an agent you already have.
+
+---
+
+## Architecture
+
+`agent callable -> trace store -> adaptive threshold -> strategy hook -> config adapter -> rollback guard -> notifier`
+
+The runtime keeps the loop inside your process:
+
+- The agent callable is the code you already run.
+- JSONL or SQLite trace storage preserves execution evidence.
+- Adaptive thresholds decide when repeated failure deserves analysis.
+- A strategy hook may propose a bounded config patch.
+- `ConfigAdapter` owns real config backup, patch, and restore.
+- Rollback checks protect against worse success rate, latency, or consecutive failures.
 
 ---
 
@@ -406,7 +445,7 @@ The wrapper adds a stable **~300 μs of fixed cost per call** (trace append + th
 
 Rerun the benchmark on your own machine with `python benchmarks/overhead.py`.
 
-Restart / recovery startup cost can be checked with:
+For startup / recovery cost:
 
 ```bash
 python benchmarks/startup_recovery.py --traces 1000 10000 100000
@@ -422,6 +461,34 @@ Separate operation costs (triggered occasionally, not per-call):
 | Failure analysis (only when threshold crossed) | ~100 ms |
 | Applying improvement config | ~200 ms |
 | Rollback execution | ~10 ms |
+
+---
+
+## Roadmap
+
+- LangGraph integration package with state-machine examples.
+- OpenTelemetry export for Langfuse, Phoenix, and Weave.
+- Evaluation harness examples for promptfoo / deepeval-style regression tests.
+- Multi-model strategy examples for OpenAI, Anthropic, Gemini, and Ollama.
+- More production adapters for config stores and agent runtimes.
+
+---
+
+## Contributing
+
+Start with a small reproducible example. Good issues include a failing trace,
+expected rollback behavior, and the command used to reproduce it.
+
+Before opening a PR:
+
+```bash
+python -m pytest -q
+python -m compileall -q self_improving_loop examples benchmarks demo
+python benchmarks/overhead.py
+```
+
+Keep examples dependency-light and avoid claims that are not backed by a test,
+verifier, trace, or release artifact.
 
 ---
 

--- a/benchmarks/overhead.py
+++ b/benchmarks/overhead.py
@@ -10,8 +10,13 @@ Usage:
 """
 
 import statistics
+import sys
 import tempfile
 import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
 
 from self_improving_loop import SelfImprovingLoop
 

--- a/benchmarks/startup_recovery.py
+++ b/benchmarks/startup_recovery.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import tempfile
 import time
+from datetime import datetime
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
 
 from self_improving_loop import SelfImprovingLoop
 
@@ -19,6 +24,7 @@ from self_improving_loop import SelfImprovingLoop
 def _seed_traces(data_dir: Path, count: int, agent_id: str) -> None:
     data_dir.mkdir(parents=True, exist_ok=True)
     traces_file = data_dir / "traces.jsonl"
+    timestamp = datetime.now().isoformat()
     with open(traces_file, "w", encoding="utf-8") as f:
         for index in range(count):
             f.write(
@@ -28,7 +34,7 @@ def _seed_traces(data_dir: Path, count: int, agent_id: str) -> None:
                         "task": f"benchmark-task-{index}",
                         "success": index % 10 != 0,
                         "duration_sec": 0.01 + (index % 5) * 0.001,
-                        "timestamp": "2026-04-26T00:00:00",
+                        "timestamp": timestamp,
                     }
                 )
                 + "\n"

--- a/demo/huggingface_space/README.md
+++ b/demo/huggingface_space/README.md
@@ -1,0 +1,19 @@
+# Hugging Face Space Demo
+
+Use this folder as the source for a public Hugging Face Space.
+
+Recommended Space settings:
+
+- SDK: `Streamlit`
+- Visibility: `Public`
+- App file: `app.py`
+
+Local smoke run:
+
+```bash
+python3 -m pip install streamlit
+python3 -m streamlit run demo/huggingface_space/app.py
+```
+
+The app is deterministic and does not call external LLM providers. It records
+success/failure traces under `.demo-traces/`, which is ignored by git.

--- a/demo/huggingface_space/app.py
+++ b/demo/huggingface_space/app.py
@@ -1,0 +1,62 @@
+"""Streamlit demo for self-improving-loop.
+
+This demo is intentionally local and deterministic. It shows the reliability
+guard around a callable without calling an external model or provider.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from self_improving_loop import SelfImprovingLoop
+
+DATA_DIR = Path(".demo-traces")
+AGENT_ID = "streamlit-demo-agent"
+
+
+def _demo_call(task: str, should_fail: bool) -> dict:
+    if should_fail:
+        raise RuntimeError("simulated agent failure")
+    return {
+        "status": "ok",
+        "handled_task": task,
+        "external_model_called": False,
+    }
+
+
+st.set_page_config(
+    page_title="self-improving-loop demo",
+    layout="centered",
+)
+
+st.title("self-improving-loop")
+st.caption("Regression guard for AI agents: trace, threshold, strategy, rollback evidence.")
+
+task = st.text_area("Agent task", value="Answer a support ticket without regressing.")
+should_fail = st.checkbox("Simulate a failing agent call")
+
+if st.button("Run guard", type="primary"):
+    loop = SelfImprovingLoop(data_dir=str(DATA_DIR), storage="sqlite")
+    result = loop.track(
+        agent_id=AGENT_ID,
+        task=task,
+        execute_fn=lambda: _demo_call(task, should_fail),
+        context={
+            "surface": "streamlit_demo",
+            "external_model_called": False,
+        },
+    )
+    stats = loop.get_improvement_stats(AGENT_ID)
+
+    st.subheader("Execution result")
+    st.json(result)
+
+    st.subheader("Agent stats")
+    st.json(stats)
+
+    if result["success"]:
+        st.success("Trace recorded. No external model call was made.")
+    else:
+        st.warning("Failure recorded honestly. The guard did not fake success.")

--- a/demo/huggingface_space/requirements.txt
+++ b/demo/huggingface_space/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.35
+# Use the verified GitHub release artifact until PyPI Trusted Publishing
+# publishes the matching 0.1.1 package.
+self-improving-loop @ https://github.com/yangfei222666-9/self-improving-loop/releases/download/v0.1.1/self_improving_loop-0.1.1-py3-none-any.whl

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -22,8 +22,8 @@ pre-commit run --all-files
 
 ## PyPI publish path
 
-The `Publish` workflow builds on every manual run and tag push. It publishes to
-PyPI only on `v*` tag pushes.
+The `Publish` workflow builds on every manual run, `v*` tag push, and published
+GitHub Release. It publishes to PyPI only for release/tag events.
 
 Required PyPI setup before tag publishing:
 
@@ -32,4 +32,5 @@ Required PyPI setup before tag publishing:
 - Workflow file: `.github/workflows/publish.yml`.
 - Project name: `self-improving-loop`.
 
-Do not store PyPI API tokens in the repository or GitHub Actions logs.
+Do not store PyPI API tokens in the repository or GitHub Actions logs. The
+workflow uses PyPI Trusted Publishing instead of a `PYPI_API_TOKEN` secret.

--- a/examples/06_hermes_skill_regression_guard.py
+++ b/examples/06_hermes_skill_regression_guard.py
@@ -92,7 +92,11 @@ class SkillConfigAdapter:
     def apply_config(self, agent_id: str, config_patch: Dict[str, Any]) -> bool:
         self.config.update(config_patch)
         self.events.append(
-            {"event": "skill_config_patch_applied", "agent_id": agent_id, "config": dict(self.config)}
+            {
+                "event": "skill_config_patch_applied",
+                "agent_id": agent_id,
+                "config": dict(self.config),
+            }
         )
         return True
 

--- a/examples/regression_rollback_demo.py
+++ b/examples/regression_rollback_demo.py
@@ -11,10 +11,10 @@ event trail written.
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import tempfile
-import argparse
 import uuid
 from pathlib import Path
 
@@ -127,7 +127,9 @@ def write_event_trail(
 
     records: list[dict] = []
     records.extend(_with_run_id({"source": "demo", **step}, run_id) for step in steps)
-    records.extend(_with_run_id({"source": "strategy", **event}, run_id) for event in strategy.events)
+    records.extend(
+        _with_run_id({"source": "strategy", **event}, run_id) for event in strategy.events
+    )
 
     if trace_path.exists():
         for line in trace_path.read_text(encoding="utf-8").splitlines():

--- a/examples/verify_agent_eval_cases.py
+++ b/examples/verify_agent_eval_cases.py
@@ -12,7 +12,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 ALLOWED_LABELS = {
     "artifact_hash_mismatch",
     "config_patch_regression",
@@ -180,4 +179,3 @@ def main(argv: list[str]) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv))
-

--- a/examples/verify_regression_rollback_event_trail.py
+++ b/examples/verify_regression_rollback_event_trail.py
@@ -11,7 +11,6 @@ import json
 import sys
 from pathlib import Path
 
-
 REQUIRED_EVENTS = {
     "baseline_pass",
     "failure_detected",
@@ -61,7 +60,9 @@ def main(argv: list[str]) -> int:
     missing_events = sorted(REQUIRED_EVENTS - events)
     has_trace = "trace" in sources
     has_rollback = "rollback" in sources
-    has_strategy_restore = any(record.get("event") == "rollback_restored_config" for record in records)
+    has_strategy_restore = any(
+        record.get("event") == "rollback_restored_config" for record in records
+    )
     final_recovered_ok = any(
         record.get("event") == "final_status_recovered"
         and ((record.get("result") or {}).get("success") is True)
@@ -80,16 +81,23 @@ def main(argv: list[str]) -> int:
     )
 
     backup_records = [record for record in records if record.get("event") == "backup_created"]
-    restore_records = [record for record in records if record.get("event") == "rollback_restored_config"]
-    expected_backup_config = backup_records[-1].get("expected_backup_config") if backup_records else None
+    restore_records = [
+        record for record in records if record.get("event") == "rollback_restored_config"
+    ]
+    expected_backup_config = (
+        backup_records[-1].get("expected_backup_config") if backup_records else None
+    )
     restored_config = restore_records[-1].get("config") if restore_records else None
-    rollback_matches_backup = bool(expected_backup_config and restored_config == expected_backup_config)
+    rollback_matches_backup = bool(
+        expected_backup_config and restored_config == expected_backup_config
+    )
 
     rollback_events = [record for record in records if record.get("event") == "rollback_executed"]
-    rollback_backup_id = ((rollback_events[-1].get("result") or {}).get("backup_id") if rollback_events else None)
+    rollback_backup_id = (
+        (rollback_events[-1].get("result") or {}).get("backup_id") if rollback_events else None
+    )
     rollback_source_matches = any(
-        record.get("source") == "rollback"
-        and record.get("backup_id") == rollback_backup_id
+        record.get("source") == "rollback" and record.get("backup_id") == rollback_backup_id
         for record in records
     )
 

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/BLOCKED_GIT_STAGE_20260517.md
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/BLOCKED_GIT_STAGE_20260517.md
@@ -1,0 +1,56 @@
+# Blocked Git Stage
+
+Status: `blocked`
+
+Recorded: `2026-05-17T16:30:21+08:00`
+
+## Verdict
+
+`blocked`
+
+## Blocked Stage
+
+`git_stage_authorization`
+
+## Failure Cause
+
+The user said `继续`, but the project rules require explicit confirmation
+before any real `git add`, branch creation, commit, push, tag, release, or PR
+operation.
+
+`继续` is not treated as authorization for git mutation.
+
+## Evidence Path
+
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl`
+
+## Side Effects
+
+No git mutation was performed.
+
+- branch created: `false`
+- staged files: `0`
+- commit created: `false`
+- push: `false`
+- release / PyPI / HF Space: `false`
+
+## Minimum Fix
+
+The human must explicitly authorize one exact git scope, for example:
+
+```text
+允许创建本地分支并按授权包执行 git add，不 commit
+```
+
+or:
+
+```text
+允许创建本地分支、git add、commit，不 push
+```
+
+## Next Allowed Action
+
+After explicit authorization, run only the authorized git scope and then write a
+staged-scope audit plus updated `summary.json` / `event_flow.jsonl`.

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/PRODUCT_DISTRIBUTION_CLOSEOUT.md
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/PRODUCT_DISTRIBUTION_CLOSEOUT.md
@@ -1,0 +1,42 @@
+# Product Distribution PR4-PR7 Closeout
+
+Verdict: `ok_local_pr_ready_external_publish_blocked`
+
+Repo: `/Users/weiwei/Desktop/self-improving-loop`
+
+Scope: `product_distribution_pr4_pr7`
+
+## What Changed
+
+- Reused the existing PyPI trusted-publishing workflow and added `release.published` as a trigger.
+- Added a bounded Streamlit demo source under `demo/huggingface_space/`.
+- Productized `README.md` with PyPI badges, install/demo/quickstart/architecture/roadmap/contribution sections.
+- Included demo files in `MANIFEST.in` so the source distribution carries the demo source.
+- Fixed benchmark checkout execution and stale benchmark timestamps.
+- Added tests for demo packaging and benchmark execution.
+- Ran project pre-commit hardening. Existing example/test files received formatter/import-order-only changes so `ruff`, `black`, and `mypy` pass.
+
+## Verification
+
+- `git diff --check`: pass
+- Workflow YAML parse: pass
+- `python3 -m compileall -q self_improving_loop examples benchmarks demo tests`: pass
+- `python3 -m pytest -q`: `69 passed`
+- `.venv/bin/pre-commit run --all-files`: pass
+- `python3 benchmarks/startup_recovery.py --traces 10 100`: pass, `success_rate=0.9`
+- Build + `twine check`: pass for wheel and sdist
+- `summary.json` + `event_flow.jsonl` parse: pass
+- `git add --dry-run .`: 22 candidate files, all in product distribution / pre-stage hardening scope
+- `staged_count`: 0
+- PR scope split review: `single_pr_preferred`, see `PR_SCOPE_SPLIT_REVIEW.md`
+- Staged scope audit: pass, see `STAGED_SCOPE_AUDIT.md`
+
+## Boundaries
+
+No `git add`, commit, push, GitHub release, PyPI upload, or Hugging Face Space creation was performed.
+
+PyPI read-only probe observed `self-improving-loop` latest as `0.1.0`, while local package metadata is `0.1.1`. Publishing `0.1.1` remains blocked on explicit user confirmation and PyPI Trusted Publishing readiness.
+
+## Next Allowed Action
+
+After review, the safe next step is an exact-scope stage/commit on a PR branch. Public release / PyPI publish / HF Space creation must stay behind separate explicit confirmation.

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md
@@ -1,0 +1,96 @@
+# PR Scope Split Review
+
+Status: `read_only_review_complete`
+
+Recorded: `2026-05-17T16:29:14+08:00`
+
+Repo: `/Users/weiwei/Desktop/self-improving-loop`
+
+## Current Git State
+
+- Branch: `main...origin/main`
+- Staged files: `0`
+- Tracked modified files: `14`
+- Untracked candidate files: `9`
+- Dry-run stage candidates after this review: `24`
+
+## Recommendation
+
+Use one local PR/commit for this batch:
+
+```text
+build: productize distribution and demo packaging
+```
+
+Reason: the files are coupled by verification gates:
+
+- `README.md` points to `demo/huggingface_space/`.
+- `MANIFEST.in` is needed so the demo source appears in the source distribution.
+- CI/publish compile gates were extended to include `demo`.
+- Benchmark fixes are covered by the new benchmark test and README benchmark command.
+- Formatter-only changes were required by the repo's own pre-commit gate.
+- `runs/ops_check/...` is the audit package for the same local PR scope.
+
+## If Split Into Smaller PRs
+
+Split only if the goal is contribution graph granularity, not engineering
+simplicity.
+
+### PR A: Release / Publish Workflow
+
+Files:
+
+- `.github/workflows/publish.yml`
+- `.github/workflows/ci.yml`
+- `docs/RELEASE_PROCESS.md`
+
+Risk: README and demo claims would still be incomplete until PR B lands.
+
+### PR B: README + Demo Distribution
+
+Files:
+
+- `README.md`
+- `.gitignore`
+- `MANIFEST.in`
+- `demo/huggingface_space/README.md`
+- `demo/huggingface_space/app.py`
+- `demo/huggingface_space/requirements.txt`
+- `tests/test_huggingface_space_demo.py`
+
+Risk: depends on PR A if CI/publish should compile the demo in automation.
+
+### PR C: Benchmark / Example Gate Hardening
+
+Files:
+
+- `benchmarks/overhead.py`
+- `benchmarks/startup_recovery.py`
+- `tests/test_benchmarks.py`
+- `examples/06_hermes_skill_regression_guard.py`
+- `examples/regression_rollback_demo.py`
+- `examples/verify_agent_eval_cases.py`
+- `examples/verify_regression_rollback_event_trail.py`
+- `tests/test_agent_eval_cases.py`
+- `tests/test_examples.py`
+
+Risk: formatter-only changes are noisy if separated from the pre-commit gate
+that required them.
+
+### PR D: Audit Artifacts
+
+Files:
+
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/PRODUCT_DISTRIBUTION_CLOSEOUT.md`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl`
+- `runs/ops_check/product_distribution_pr4_pr7_20260517/summary.json`
+
+Risk: keeping audit artifacts outside the PR weakens the TaijiOS evidence
+contract. Keeping them inside the same PR is preferable for this project.
+
+## Boundary
+
+No git mutation was performed while creating this review. Real staging still
+requires explicit user authorization.

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/STAGED_SCOPE_AUDIT.md
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/STAGED_SCOPE_AUDIT.md
@@ -1,0 +1,80 @@
+# Staged Scope Audit
+
+Status: `pass`
+
+Recorded: `2026-05-17T16:38:30+08:00`
+
+Branch: `product/distribution-demo-pypi`
+
+## Authorized Scope
+
+Authorized by user:
+
+```text
+允许创建本地分支、git add、commit，不 push
+```
+
+Allowed actions performed:
+
+- local branch creation
+- `git add`
+
+Still forbidden:
+
+- push
+- tag
+- release
+- PR creation
+- PyPI upload
+- Hugging Face Space creation
+- secret read/export
+
+## Staged Files
+
+Staged before this audit artifact: `25`
+
+```text
+.github/workflows/ci.yml
+.github/workflows/publish.yml
+.gitignore
+MANIFEST.in
+README.md
+benchmarks/overhead.py
+benchmarks/startup_recovery.py
+demo/huggingface_space/README.md
+demo/huggingface_space/app.py
+demo/huggingface_space/requirements.txt
+docs/RELEASE_PROCESS.md
+examples/06_hermes_skill_regression_guard.py
+examples/regression_rollback_demo.py
+examples/verify_agent_eval_cases.py
+examples/verify_regression_rollback_event_trail.py
+runs/ops_check/product_distribution_pr4_pr7_20260517/BLOCKED_GIT_STAGE_20260517.md
+runs/ops_check/product_distribution_pr4_pr7_20260517/PRODUCT_DISTRIBUTION_CLOSEOUT.md
+runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md
+runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md
+runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl
+runs/ops_check/product_distribution_pr4_pr7_20260517/summary.json
+tests/test_agent_eval_cases.py
+tests/test_benchmarks.py
+tests/test_examples.py
+tests/test_huggingface_space_demo.py
+```
+
+This audit file is added after that count, so the final staged count for the
+commit is expected to be `26`.
+
+## Verification
+
+- `git diff --cached --check`: pass
+- `git diff --name-only`: empty after restaging fixed imports
+- `.venv/bin/pre-commit run --all-files`: pass
+- `python3 -m compileall -q self_improving_loop examples benchmarks demo tests`: pass
+- `python3 -m pytest -q`: `69 passed`
+- `summary.json` / `event_flow.jsonl`: parseable
+
+## Notes
+
+The first staged pre-commit run found import-order fixes in new demo/test
+files. `ruff check --fix` repaired them, and those files were restaged before
+this audit.

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md
@@ -1,0 +1,81 @@
+# Stage Authorization Packet
+
+Status: `authorized_local_branch_stage_commit_no_push`
+
+Created: `2026-05-17T16:28:07+08:00`
+
+Repo: `/Users/weiwei/Desktop/self-improving-loop`
+
+## Boundary
+
+This packet does not authorize staging by itself. It exists so the human can
+confirm the exact staging scope.
+
+Authorization received at `2026-05-17T16:37:22+08:00` for local branch
+creation, `git add`, and commit only. Push, tag, release, PyPI upload, and
+Hugging Face Space creation remain blocked.
+
+## Recommended Branch
+
+```bash
+git switch -c product/distribution-demo-pypi
+```
+
+This changes local git branch state, so it still requires explicit user
+confirmation before execution.
+
+## Recommended Stage Command
+
+Use explicit paths instead of `git add .`:
+
+```bash
+git add \
+  .github/workflows/ci.yml \
+  .github/workflows/publish.yml \
+  .gitignore \
+  MANIFEST.in \
+  README.md \
+  benchmarks/overhead.py \
+  benchmarks/startup_recovery.py \
+  demo/huggingface_space/README.md \
+  demo/huggingface_space/app.py \
+  demo/huggingface_space/requirements.txt \
+  docs/RELEASE_PROCESS.md \
+  examples/06_hermes_skill_regression_guard.py \
+  examples/regression_rollback_demo.py \
+  examples/verify_agent_eval_cases.py \
+  examples/verify_regression_rollback_event_trail.py \
+  runs/ops_check/product_distribution_pr4_pr7_20260517/PRODUCT_DISTRIBUTION_CLOSEOUT.md \
+  runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md \
+  runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl \
+  runs/ops_check/product_distribution_pr4_pr7_20260517/summary.json \
+  tests/test_agent_eval_cases.py \
+  tests/test_benchmarks.py \
+  tests/test_examples.py \
+  tests/test_huggingface_space_demo.py
+```
+
+## Recommended Commit
+
+```bash
+git commit -m "build: productize distribution and demo packaging"
+```
+
+Commit also requires explicit user confirmation.
+
+## Verified Gates
+
+- `pre-commit run --all-files`: pass
+- `python3 -m pytest -q`: `69 passed`
+- `python3 -m compileall -q self_improving_loop examples benchmarks demo tests`: pass
+- build + `twine check`: pass
+- `git diff --check`: pass
+- `summary.json` + `event_flow.jsonl`: parseable
+- current `staged_count`: `0`
+
+## External Publish Blockers
+
+- PyPI publish is blocked until user confirms release/tag publishing and PyPI
+  Trusted Publishing readiness.
+- Hugging Face Space public URL is blocked until user confirms creating or
+  uploading to a public external Space.

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/event_flow.jsonl
@@ -1,0 +1,42 @@
+{"ts":"2026-05-17T16:20:09+08:00","event":"scope_declared","scope":"product_distribution_pr4_pr7","mode":"edit","repo_root":"/Users/weiwei/Desktop/self-improving-loop","will_not":["git_add","commit","push","release","pypi_upload","hf_space_create","secret_read"]}
+{"ts":"2026-05-17T16:20:09+08:00","event":"repo_selected","candidate":"/Users/weiwei/Desktop/self-improving-loop","reason":"clean git worktree and package name matches self-improving-loop"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"preflight_inventory","pyproject_version":"0.1.1","init_version":"0.1.1","existing_publish_workflow":true,"existing_examples":true,"existing_benchmarks":true}
+{"ts":"2026-05-17T16:20:09+08:00","event":"pypi_probe","command":"python3 -m pip index versions self-improving-loop","status":"ok","observed_latest":"0.1.0","local_version":"0.1.1"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"edit","files":[".github/workflows/publish.yml",".github/workflows/ci.yml",".gitignore","MANIFEST.in","README.md","docs/RELEASE_PROCESS.md","demo/huggingface_space/app.py","demo/huggingface_space/requirements.txt","demo/huggingface_space/README.md"]}
+{"ts":"2026-05-17T16:20:09+08:00","event":"benchmark_bug_found","file":"benchmarks/startup_recovery.py","cause":"direct checkout execution could not import self_improving_loop; fixed import path in benchmark scripts"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"stale_benchmark_found","file":"benchmarks/startup_recovery.py","cause":"fixed 2026-04-26 timestamp made current-window success_rate report 0.0; replaced with runtime timestamp"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"tests_added","files":["tests/test_benchmarks.py","tests/test_huggingface_space_demo.py"]}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"git diff --check","status":"pass"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"ruby yaml parse for ci.yml and publish.yml","status":"pass"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"python3 -m compileall -q self_improving_loop examples benchmarks demo tests","status":"pass"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"python3 -m pytest -q","status":"pass","result":"69 passed in 1.53s"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"python3 benchmarks/startup_recovery.py --traces 10 100","status":"pass","result":"success_rate=0.9 for both trace counts"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"verifier","command":"build and twine check in ignored .venv with temp dist","status":"pass","dist_dir":"/tmp/self_improving_loop_dist_vojeb1"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"artifact_parse","command":"parse summary.json and event_flow.jsonl","status":"pass"}
+{"ts":"2026-05-17T16:20:09+08:00","event":"scope_dry_run","command":"git add --dry-run .","status":"pass","candidate_file_count":16,"changed_files_outside_scope":0}
+{"ts":"2026-05-17T16:20:09+08:00","event":"staged_count","command":"git diff --cached --name-only | wc -l","status":"pass","staged_count":0}
+{"ts":"2026-05-17T16:20:09+08:00","event":"boundary","pypi_upload":false,"hf_space_create":false,"git_stage":false,"git_commit":false,"git_push":false,"reason":"external visible and git state-changing actions require user confirmation"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"continue_scope","scope":"product_distribution_pre_stage_hardening","mode":"verify","will_not":["git_add","commit","push","release","pypi_upload","hf_space_create","secret_read"]}
+{"ts":"2026-05-17T16:26:50+08:00","event":"tool_install","target":".venv","packages":["pre-commit","ruff","black","mypy"],"status":"ok","artifact_boundary":"ignored local venv only"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"pre_commit_first_run","command":".venv/bin/pre-commit run --all-files","status":"failed_then_modified","cause":"ruff import ordering and black formatting changes in existing examples/tests; mypy passed"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"format_fix","command":".venv/bin/ruff check --fix examples/regression_rollback_demo.py examples/verify_regression_rollback_event_trail.py tests/test_examples.py tests/test_agent_eval_cases.py examples/verify_agent_eval_cases.py","status":"pass","result":"5 fixed"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"pre_commit_final","command":".venv/bin/pre-commit run --all-files","status":"pass","checks":["ruff check","black","mypy"]}
+{"ts":"2026-05-17T16:26:50+08:00","event":"verifier","command":"git diff --check","status":"pass"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"verifier","command":"python3 -m compileall -q self_improving_loop examples benchmarks demo tests","status":"pass"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"verifier","command":"python3 -m pytest -q","status":"pass","result":"69 passed in 6.84s"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"verifier","command":"python3 benchmarks/startup_recovery.py --traces 10 100","status":"pass","result":"success_rate=0.9 for both trace counts"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"verifier","command":"build and twine check in ignored .venv with temp dist","status":"pass","dist_dir":"/tmp/self_improving_loop_dist_ojIJhE"}
+{"ts":"2026-05-17T16:26:50+08:00","event":"scope_dry_run","command":"git add --dry-run .","status":"pass","candidate_file_count":22,"changed_files_outside_scope":0}
+{"ts":"2026-05-17T16:26:50+08:00","event":"staged_count","command":"git diff --cached --name-only | wc -l","status":"pass","staged_count":0}
+{"ts":"2026-05-17T16:28:07+08:00","event":"continue_scope","scope":"stage_authorization_packet_only","mode":"package","will_not":["git_add","commit","push","release","pypi_upload","hf_space_create","secret_read"]}
+{"ts":"2026-05-17T16:28:07+08:00","event":"stage_authorization_packet_written","path":"runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md","status":"awaiting_user_confirmation","recommended_stage_style":"explicit_paths"}
+{"ts":"2026-05-17T16:29:14+08:00","event":"continue_scope","scope":"pr_scope_split_review_no_git_mutation","mode":"package","will_not":["git_add","commit","push","branch_create","release","pypi_upload","hf_space_create","secret_read"]}
+{"ts":"2026-05-17T16:29:14+08:00","event":"pr_scope_split_review_written","path":"runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md","status":"read_only_review_complete","recommendation":"single_pr_preferred","staged_count":0}
+{"ts":"2026-05-17T16:30:21+08:00","event":"blocked","scope":"blocked_git_stage_closeout","blocked_stage":"git_stage_authorization","failure_cause":"user said continue, but explicit git mutation authorization is required before git add, branch creation, commit, push, tag, release, or PR operations","evidence_path":"runs/ops_check/product_distribution_pr4_pr7_20260517/BLOCKED_GIT_STAGE_20260517.md","staged_count":0,"next_allowed_action":"wait for explicit git authorization"}
+{"ts":"2026-05-17T16:37:22+08:00","event":"authorization_received","scope":"authorized_local_branch_stage_commit_no_push","authorized_actions":["create_local_branch","git_add","git_commit"],"forbidden_actions":["push","tag","release","pr","pypi_upload","hf_space_create","secret_read"],"user_text":"允许创建本地分支、git add、commit，不 push"}
+{"ts":"2026-05-17T16:37:22+08:00","event":"branch_created","branch":"product/distribution-demo-pypi","status":"ok"}
+{"ts":"2026-05-17T16:38:30+08:00","event":"git_add","stage_style":"explicit_paths","status":"ok","staged_count_before_audit":25}
+{"ts":"2026-05-17T16:38:30+08:00","event":"pre_commit_after_stage_first_run","status":"failed","cause":"new demo/test files needed ruff import-order fixes","black":"pass","mypy":"pass","pytest":"pass","compileall":"pass"}
+{"ts":"2026-05-17T16:38:30+08:00","event":"format_fix","command":".venv/bin/ruff check --fix demo/huggingface_space/app.py tests/test_benchmarks.py tests/test_huggingface_space_demo.py","status":"pass","result":"3 fixed"}
+{"ts":"2026-05-17T16:38:30+08:00","event":"pre_commit_after_stage_final","command":".venv/bin/pre-commit run --all-files","status":"pass","checks":["ruff check","black","mypy"]}
+{"ts":"2026-05-17T16:38:30+08:00","event":"staged_scope_audit_written","path":"runs/ops_check/product_distribution_pr4_pr7_20260517/STAGED_SCOPE_AUDIT.md","status":"pass","expected_final_staged_count":26}

--- a/runs/ops_check/product_distribution_pr4_pr7_20260517/summary.json
+++ b/runs/ops_check/product_distribution_pr4_pr7_20260517/summary.json
@@ -1,0 +1,129 @@
+{
+  "verdict": "ok_local_pr_ready_external_publish_blocked",
+  "scope": "product_distribution_pr4_pr7",
+  "mode": "edit",
+  "repo_root": "/Users/weiwei/Desktop/self-improving-loop",
+  "base_commit": "bedb1b3",
+  "completed_at": "2026-05-17T16:26:50+08:00",
+  "changed_files_outside_scope": 0,
+  "staged_count": 0,
+  "local_package_version": "0.1.1",
+  "pypi_observed_latest": "0.1.0",
+  "pypi_probe_command": "python3 -m pip index versions self-improving-loop",
+  "external_actions": {
+    "git_stage": false,
+    "git_commit": false,
+    "git_push": false,
+    "github_release": false,
+    "pypi_upload": false,
+    "huggingface_space_create": false
+  },
+  "stage_authorization": {
+    "status": "awaiting_user_confirmation",
+    "packet": "runs/ops_check/product_distribution_pr4_pr7_20260517/STAGE_AUTHORIZATION_PACKET.md",
+    "recommended_branch": "product/distribution-demo-pypi",
+    "recommended_commit_message": "build: productize distribution and demo packaging"
+  },
+  "scope_split_review": {
+    "status": "read_only_review_complete",
+    "packet": "runs/ops_check/product_distribution_pr4_pr7_20260517/PR_SCOPE_SPLIT_REVIEW.md",
+    "recommendation": "single_pr_preferred",
+    "reason": "README, demo, manifest, workflow, benchmark test, formatter, and audit artifacts are coupled by the verified release gate."
+  },
+  "git_authorization": {
+    "status": "authorized_local_only",
+    "authorized_actions": [
+      "create_local_branch",
+      "git_add",
+      "git_commit"
+    ],
+    "forbidden_actions": [
+      "push",
+      "tag",
+      "release",
+      "pr",
+      "pypi_upload",
+      "hf_space_create",
+      "secret_read"
+    ],
+    "authorized_at": "2026-05-17T16:37:22+08:00",
+    "branch": "product/distribution-demo-pypi"
+  },
+  "staged_scope_audit": {
+    "status": "pass",
+    "path": "runs/ops_check/product_distribution_pr4_pr7_20260517/STAGED_SCOPE_AUDIT.md",
+    "staged_count_before_audit": 25,
+    "expected_final_staged_count": 26,
+    "unstaged_after_restaging": 0
+  },
+  "changes": [
+    "Added release.published trigger to the existing trusted-publishing workflow instead of creating a duplicate PyPI uploader.",
+    "Added Hugging Face / Streamlit demo source under demo/huggingface_space with deterministic no-provider execution.",
+    "Productized README with PyPI badges, install path, demo path, quickstart, architecture, roadmap, and contribution guidance.",
+    "Included demo files in the source distribution via MANIFEST.in.",
+    "Fixed benchmark scripts so they run from a clean checkout and removed stale timestamp behavior from startup_recovery.py.",
+    "Added tests for the Space demo files and benchmark checkout execution.",
+    "Ran pre-commit hardening and accepted formatter-only changes in existing example/test files so the release gate passes."
+  ],
+  "verification": [
+    {
+      "command": "git diff --check",
+      "status": "pass"
+    },
+    {
+      "command": "ruby -e 'require \"yaml\"; ARGV.each { |f| YAML.load_file(f); puts \"yaml ok #{f}\" }' .github/workflows/ci.yml .github/workflows/publish.yml",
+      "status": "pass"
+    },
+    {
+      "command": "python3 -m compileall -q self_improving_loop examples benchmarks demo tests",
+      "status": "pass"
+    },
+    {
+      "command": "python3 -m pytest -q",
+      "status": "pass",
+      "result": "69 passed in 6.84s"
+    },
+    {
+      "command": ".venv/bin/pre-commit run --all-files",
+      "status": "pass",
+      "result": "ruff check, black, mypy passed after formatter/import-order fixes"
+    },
+    {
+      "command": "python3 benchmarks/startup_recovery.py --traces 10 100",
+      "status": "pass",
+      "result": "trace_count=10 success_rate=0.9; trace_count=100 success_rate=0.9"
+    },
+    {
+      "command": ".venv/bin/python -m build --outdir /tmp/self_improving_loop_dist_ojIJhE && .venv/bin/python -m twine check /tmp/self_improving_loop_dist_ojIJhE/*",
+      "status": "pass",
+      "result": "wheel and sdist built; twine check passed"
+    },
+    {
+      "command": "python3 parse summary.json and event_flow.jsonl",
+      "status": "pass",
+      "result": "artifact_parse=ok"
+    },
+    {
+      "command": "git add --dry-run .",
+      "status": "pass",
+      "result": "22 candidate files, all within product_distribution_pr4_pr7 plus pre_stage_hardening scope"
+    },
+    {
+      "command": "git diff --cached --name-only | wc -l",
+      "status": "pass",
+      "result": "0"
+    }
+  ],
+  "blocked_external_steps": [
+    {
+      "stage": "pypi_publish_0.1.1",
+      "cause": "External publish requires user authorization and PyPI trusted publishing configuration.",
+      "minimum_fix": "Confirm release/tag publish after reviewing this local PR scope."
+    },
+    {
+      "stage": "huggingface_space_public_url",
+      "cause": "Creating a public Space is an external visible remote action.",
+      "minimum_fix": "User confirms HF Space creation/upload, then use demo/huggingface_space as source."
+    }
+  ]
+}

--- a/tests/test_agent_eval_cases.py
+++ b/tests/test_agent_eval_cases.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -28,4 +27,3 @@ def test_agent_eval_cases_verify():
     assert "paper_buy_allowed=false" in result.stdout
     assert "trade_allowed=false" in result.stdout
     assert "promote_allowed=false" in result.stdout
-

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_startup_recovery_benchmark_runs_from_checkout():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "benchmarks" / "startup_recovery.py"),
+            "--traces",
+            "10",
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads(result.stdout.strip())
+    assert record["trace_count"] == 10
+    assert record["total_tasks"] == 10
+    assert record["success_rate"] == 0.9
+    assert "calculate_metrics_ms" in record

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,8 +3,8 @@
 import json
 import subprocess
 import sys
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -174,12 +174,37 @@ def _valid_records():
     backup = {"mode": "baseline", "timeout_sec": 30, "prompt_variant": "safe-v1"}
     return [
         {"source": "demo", "run_id": run_id, "event": "baseline_pass", "result": {"success": True}},
-        {"source": "demo", "run_id": run_id, "event": "failure_detected", "result": {"success": False}},
-        {"source": "demo", "run_id": run_id, "event": "backup_created", "expected_backup_config": backup},
-        {"source": "strategy", "run_id": run_id, "event": "rollback_restored_config", "config": backup},
-        {"source": "demo", "run_id": run_id, "event": "rollback_executed", "result": {"backup_id": "b1"}},
+        {
+            "source": "demo",
+            "run_id": run_id,
+            "event": "failure_detected",
+            "result": {"success": False},
+        },
+        {
+            "source": "demo",
+            "run_id": run_id,
+            "event": "backup_created",
+            "expected_backup_config": backup,
+        },
+        {
+            "source": "strategy",
+            "run_id": run_id,
+            "event": "rollback_restored_config",
+            "config": backup,
+        },
+        {
+            "source": "demo",
+            "run_id": run_id,
+            "event": "rollback_executed",
+            "result": {"backup_id": "b1"},
+        },
         {"source": "rollback", "run_id": run_id, "backup_id": "b1", "config_restored": backup},
-        {"source": "demo", "run_id": run_id, "event": "final_status_recovered", "result": {"success": True}},
+        {
+            "source": "demo",
+            "run_id": run_id,
+            "event": "final_status_recovered",
+            "result": {"success": True},
+        },
         {"source": "trace", "run_id": run_id, "agent_id": "support-agent-demo", "success": False},
     ]
 

--- a/tests/test_huggingface_space_demo.py
+++ b/tests/test_huggingface_space_demo.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPACE_DIR = ROOT / "demo" / "huggingface_space"
+
+
+def test_huggingface_space_demo_files_exist():
+    assert (SPACE_DIR / "app.py").exists()
+    assert (SPACE_DIR / "requirements.txt").exists()
+
+
+def test_huggingface_space_demo_is_bounded_and_package_backed():
+    app = (SPACE_DIR / "app.py").read_text(encoding="utf-8")
+    requirements = (SPACE_DIR / "requirements.txt").read_text(encoding="utf-8")
+
+    assert "SelfImprovingLoop" in app
+    assert "external_model_called" in app
+    assert "simulated agent failure" in app
+    assert "streamlit" in requirements
+    assert "self-improving-loop" in requirements


### PR DESCRIPTION
## Summary

- Add release-published support to the existing PyPI trusted-publishing workflow.
- Add a bounded Streamlit / Hugging Face Space demo source under `demo/huggingface_space/`.
- Productize the README with PyPI badges, install/demo/quickstart/architecture/roadmap/contribution sections.
- Include demo files in the source distribution and extend compile gates to cover `demo/`.
- Fix benchmark checkout execution and stale startup-recovery timestamps.
- Add tests for benchmark execution and demo packaging.
- Include TaijiOS ops-check artifacts for scope, staging, and closeout evidence.

## Verification

- `.venv/bin/pre-commit run --all-files` passed.
- `python3 -m pytest -q` passed with `69 passed`.
- `python3 -m compileall -q self_improving_loop examples benchmarks demo tests` passed.
- build + `twine check` passed for wheel and sdist.
- `git diff --cached --check` passed before commit.
- `summary.json` and `event_flow.jsonl` parsed successfully.

## Boundaries

This PR does not publish a release, upload to PyPI, create a Hugging Face Space, tag, or merge itself. PyPI publish and public demo deployment remain separate manual gates.